### PR TITLE
Adding a missing endpoint from the application API side, specifically for user.

### DIFF
--- a/pterodactyl/application/users.md
+++ b/pterodactyl/application/users.md
@@ -35,6 +35,10 @@ Returns a list of user objects.
 
 Returns a user by its `id` (number). Supports the above "include" parameter.
 
+### `GET /users/external/:external_id`
+
+Return a user by its 'external_id` (string). Supports the above "include" parameter.
+
 ### `POST /users`
 
 Creates a user.

--- a/pterodactyl/application/users.md
+++ b/pterodactyl/application/users.md
@@ -37,7 +37,7 @@ Returns a user by its `id` (number). Supports the above "include" parameter.
 
 ### `GET /users/external/:external_id`
 
-Return a user by its 'external_id` (string). Supports the above "include" parameter.
+Return a user by its `external_id` (string). Supports the above "include" parameter.
 
 ### `POST /users`
 


### PR DESCRIPTION
Hey, I know it's a small little commit but I thought it should be included. I have tested this against a panel of mine, and verified everything:

The endpoint being: `/application/users/external/:external_id`

- That `external_id` is only valid as a string.
- The endpoint does work as intended (via Postman).
- The endpoint does support the include parameters.

: D