### PR TITLE
Added the values for data.part[] on POST /api/remote/backups/:backup

### DIFF
--- a/pterodactyl/remote/server_backups.md
+++ b/pterodactyl/remote/server_backups.md
@@ -35,8 +35,8 @@ Handles updating the state of a backup.
 | data.checksum_type       | required if success is true | string  | The checksum type.                                                                                     |
 | data.size                | required if success is true | number  | The size of the backup.                                                                                |
 | data.parts               | optional                    | array   | An array containing the etag and part number for each part.                                            |
-| data.parts[].etag        | required                    | string  | ???                                                                                                    |
-| data.parts[].part_number | required                    | number  | ???                                                                                                    |
+| data.parts[].etag        | required                    | string  | The entity tag of an upload part. (for S3)                                                             |
+| data.parts[].part_number | required                    | number  | The part number of an upload part. (for S3)                                                            |
 
 ### Example Body
 


### PR DESCRIPTION
On https://github.com/devnote-dev/ptero-notes/pull/15#issuecomment-1610635315, I couldn't figure out what `data.parts[]` does on [POST /api/remote/backups/:backup](https://github.com/devnote-dev/ptero-notes/blob/main/pterodactyl/remote/server_backups.md#post-apiremotebackupsbackup), and I left them as "???".

I decided to actually do some research to figure out what `data.parts[].etag` (entity tag) and `data.parts[].part_number` does, and I figured out it's supposed to be related with S3.

Where the panel uses these variables: [panel/app/Http/Controllers/Api/Remote/Backups/BackupStatusController.php:L61](https://github.com/pterodactyl/panel/blob/a9bdf7a1ef27a65f07ebbf71d8ea20285cdaf30f/app/Http/Controllers/Api/Remote/Backups/BackupStatusController.php#L61)
Where Wings uses these variables: [wings/server/backup/backup_s3.go:L142](https://github.com/pterodactyl/wings/blob/d30ab7b9bd018042033a2b1f60dad2f04eaf9883/server/backup/backup_s3.go#L142)

https://docs.aws.amazon.com/AmazonS3/latest/userguide/mpuoverview.html states:

So, I'm guessing this is used in S3 to upload backups/files in "parts".
