### PR TITLE
Add Futures Document

### DIFF
--- a/futures.md
+++ b/futures.md
@@ -1,0 +1,44 @@
+# Future Changes
+
+This document outlines proposed and confirmed features and changes to new versions of Pterodactyl. Currently, the future features and changes listed in this document are for Pterodactyl v2 which is in ongoing development.
+
+## Confirmed
+
+These are features/changes that have been confirmed to appear in future releases by one or more members of the Pterodactyl core team.
+
+- https://github.com/pterodactyl/panel/issues/279
+- https://github.com/pterodactyl/panel/issues/278
+- https://github.com/pterodactyl/panel/issues/3435
+- https://github.com/pterodactyl/panel/issues/2878
+- https://github.com/pterodactyl/panel/issues/4443
+- https://github.com/pterodactyl/panel/issues/2518
+- https://github.com/pterodactyl/panel/issues/4533
+- https://github.com/pterodactyl/panel/issues/4569
+- https://github.com/pterodactyl/panel/issues/4655
+- https://github.com/pterodactyl/panel/issues/4877
+- https://github.com/pterodactyl/panel/pull/4509
+- https://github.com/pterodactyl/panel/pull/4872
+- https://github.com/pterodactyl/panel/pull/4873
+- https://github.com/pterodactyl/panel/pull/4869
+- https://github.com/pterodactyl/panel/pull/4866
+
+## Proposed
+
+These are features/changes that have been proposed on the GitHub repository and have relevant discussions in the issue or from the Discord server.
+
+- https://github.com/pterodactyl/panel/issues/291
+- https://github.com/pterodactyl/panel/issues/4446
+- https://github.com/pterodactyl/panel/issues/4387
+- https://github.com/pterodactyl/panel/issues/4377
+- https://github.com/pterodactyl/panel/issues/3588
+- https://github.com/pterodactyl/panel/issues/4337
+- https://github.com/pterodactyl/panel/issues/3846
+- https://github.com/pterodactyl/panel/issues/3828
+- https://github.com/pterodactyl/panel/issues/3640
+- https://github.com/pterodactyl/panel/issues/2754
+- https://github.com/pterodactyl/panel/issues/2702
+- https://github.com/pterodactyl/panel/issues/2615
+- https://github.com/pterodactyl/panel/issues/2594
+- https://github.com/pterodactyl/panel/issues/2584
+- https://github.com/pterodactyl/panel/issues/2483
+- https://github.com/pterodactyl/panel/issues/2234

--- a/futures.md
+++ b/futures.md
@@ -22,6 +22,14 @@ These are features/changes that have been confirmed to appear in future releases
 - https://github.com/pterodactyl/panel/pull/4869
 - https://github.com/pterodactyl/panel/pull/4866
 
+### API Access
+
+Application API keys have been deprecated in favour of client API keys which have access to application API endpoints for administrative accounts from version 1.8 or later. Eventually they will be removed entirely and client API keys will be reimplemented as "Access Tokens".
+
+### Admin-Application Endpoints
+
+The **admin** API which is used for the admin controls in the panel (not to be confused with the **application** API) will be integrated into the application API. This means that resources formerly only accessible via the admin web view will now be accessible externally through the use of an API key (e.g. managing mounts).
+
 ## Proposed
 
 These are features/changes that have been proposed on the GitHub repository and have relevant discussions in the issue or from the Discord server.


### PR DESCRIPTION
Adds the current available future features and changes organised from the Pterodactyl repository. Closes #12.